### PR TITLE
T07：Form モデル作成と公開ページへのフォーム常時表示

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,22 @@
+name: Claude Code Review (mention)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '@claude')
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,0 +1,5 @@
+class FormsController < PublicController
+  def thanks
+    @form = Form.find(params[:id])
+  end
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,0 +1,3 @@
+class Form < ApplicationRecord
+  validates :name, presence: true
+end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -8,3 +8,5 @@
     <%= link_to "← 記事一覧に戻る", articles_path, class: "text-blue-600 hover:underline" %>
   </div>
 </article>
+
+<%= render "shared/form_for_visitor" %>

--- a/app/views/forms/thanks.html.erb
+++ b/app/views/forms/thanks.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, "送信完了" %>
+
+<section class="w-full text-center py-12">
+  <h1 class="text-3xl font-bold mb-4"><%= @form.success_message.presence || "送信ありがとうございました" %></h1>
+  <%= link_to "トップへ戻る", root_path, class: "text-blue-600 hover:underline" %>
+</section>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -8,3 +8,5 @@
   </p>
   <%= link_to "記事一覧を見る", articles_path, class: "inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700" %>
 </section>
+
+<%= render "shared/form_for_visitor" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="container mx-auto mt-28 px-5 flex flex-col">
       <%= yield %>
     </main>
   </body>

--- a/app/views/shared/_form_for_visitor.html.erb
+++ b/app/views/shared/_form_for_visitor.html.erb
@@ -1,0 +1,14 @@
+<section class="mt-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
+  <h2 class="text-xl font-bold mb-4">お問い合わせ</h2>
+  <%= form_with url: "#", method: :post do |f| %>
+    <div class="mb-4">
+      <%= f.label :name, "お名前", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :name, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div class="mb-4">
+      <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.email_field :email, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <%= f.submit "送信する", class: "bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700" %>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   # 公開側
   root "home#show"
   resources :articles, only: %i[index show]
+  resources :forms, only: [] do
+    member { get :thanks }
+  end
 
   # 管理側(認証必須)。中身は後続チケットで追加する。
   namespace :admin do

--- a/db/migrate/20260428102913_create_forms.rb
+++ b/db/migrate/20260428102913_create_forms.rb
@@ -1,8 +1,8 @@
 class CreateForms < ActiveRecord::Migration[8.1]
   def change
     create_table :forms do |t|
-      t.string :name
-      t.string :description
+      t.string :name, null: false
+      t.text :description
       t.string :success_message
 
       t.timestamps

--- a/db/migrate/20260428102913_create_forms.rb
+++ b/db/migrate/20260428102913_create_forms.rb
@@ -1,0 +1,11 @@
+class CreateForms < ActiveRecord::Migration[8.1]
+  def change
+    create_table :forms do |t|
+      t.string :name
+      t.string :description
+      t.string :success_message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_102913) do
   create_table "articles", force: :cascade do |t|
     t.text "body", null: false
     t.datetime "created_at", null: false
@@ -29,6 +29,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_000000) do
     t.index ["event_type"], name: "index_events_on_event_type"
     t.index ["visitor_id", "occurred_at"], name: "index_events_on_visitor_id_and_occurred_at"
     t.index ["visitor_id"], name: "index_events_on_visitor_id"
+  end
+
+  create_table "forms", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "description"
+    t.string "name"
+    t.string "success_message"
+    t.datetime "updated_at", null: false
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,8 +33,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_28_102913) do
 
   create_table "forms", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "description"
-    t.string "name"
+    t.text "description"
+    t.string "name", null: false
     t.string "success_message"
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :form do
+    name { "MyString" }
+    description { "MyString" }
+    success_message { "MyString" }
+  end
+end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :form do
-    name { "MyString" }
-    description { "MyString" }
-    success_message { "MyString" }
+    name { "お問い合わせフォーム" }
+    description { "気軽にお問い合わせください" }
+    success_message { "送信ありがとうございました" }
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Form, type: :model do
+  describe "validations" do
+    it "name がない Form は無効" do
+      form = Form.new(name: nil)
+      expect(form).not_to be_valid
+      expect(form.errors[:name]).to be_present
+    end
+  end
+end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Forms", type: :request do
+  describe "GET /forms/:id/thanks" do
+    it "200 を返す" do
+      form = create(:form)
+
+      get thanks_form_path(form)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "Articles", type: :system do
+  before { driven_by(:rack_test) }
+
+  it "記事詳細ページに訪問するとフォームが表示される" do
+    form = create(:form)
+    article = create(:article)
+
+    visit article_path(article)
+
+    expect(page).to have_css("form")
+  end
+end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "Articles", type: :system do
   before { driven_by(:rack_test) }
 
   it "記事詳細ページに訪問するとフォームが表示される" do
-    form = create(:form)
     article = create(:article)
 
     visit article_path(article)

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe "Home", type: :system do
   before { driven_by(:rack_test) }
 
   it "トップページ(LP)に訪問するとフォームが表示される" do
-    create(:form)
-
     visit root_path
 
     expect(page).to have_css("form")

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Home", type: :system do
+  before { driven_by(:rack_test) }
+
+  it "トップページ(LP)に訪問するとフォームが表示される" do
+    create(:form)
+
+    visit root_path
+
+    expect(page).to have_css("form")
+  end
+end


### PR DESCRIPTION
## 概要

`Form` モデルと問い合わせフォーム UI を追加し、トップページ・記事詳細ページにフォームを常時表示する。
フォーム送信処理は T08 で実装するため、このチケットでは表示のみ。

## 変更内容

**モデル・DB**
- `Form` モデルを追加（`name` / `description` / `success_message` カラム）
- `name` の presence バリデーションを追加
- `create_forms` マイグレーションを追加

**コントローラ・ルーティング**
- `FormsController#thanks` アクションを追加（`PublicController` 継承）
- `routes.rb` に `resources :forms, only: [] do member { get :thanks } end` を追加

**ビュー**
- `shared/_form_for_visitor.html.erb` を新規作成（お名前・メールアドレス・送信ボタン）
- `forms/thanks.html.erb` を新規作成（送信完了画面）
- `articles/show.html.erb` と `home/show.html.erb` にフォームを埋め込み

**レイアウト修正**
- `application.html.erb` の `main` タグを `flex` → `flex flex-col` に変更（フォームがコンテンツと横並びになる問題を修正）

**テスト**
- モデルスペック: `name` なし Form が無効であること
- リクエストスペック: `GET /forms/:id/thanks` が 200 を返すこと
- システムスペック: 記事詳細ページ・トップページにフォームが表示されること

## 影響範囲

- 公開ページ全体（`/` と `/articles/:id`）にフォームが表示される
- `application.html.erb` の `flex-col` 変更はすべてのページのレイアウトに影響する（admin 含む）
- DB migration あり（`forms` テーブル追加）

## 動作確認

- トップページ・記事詳細ページでフォームが縦積みで表示されることをブラウザで確認済み
- フォームの送信先 URL は `"#"` のプレースホルダー（送信しても動作しない。T08 で実装）

## テスト

```
bundle exec rspec spec/
# 39 examples, 0 failures
```

## レビューで見てほしい点

- `shared/_form_for_visitor.html.erb` の `form_with url: "#"` は T08 で送信先に差し替える。現時点では意図的なプレースホルダー
- `flex-col` への変更で既存ページのレイアウトが崩れていないか

## 未確認・懸念点

- 特になし